### PR TITLE
Use helm-goto-char to show match and reveal outlines

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -315,7 +315,7 @@ Default behaviour shows finish and result in mode-line."
       (forward-line (1- (string-to-number line))))
     (ignore-errors
       (and (re-search-forward helm-ag--last-query (line-end-position) t)
-           ;; `helm-goto-char' exapnds folded headings/outlines if needed
+           ;; `helm-goto-char' expands folded headings/outlines if needed
            (helm-goto-char (match-beginning 0))))))
 
 (defun helm-ag--open-file-with-temp-buffer (filename)

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -315,7 +315,8 @@ Default behaviour shows finish and result in mode-line."
       (forward-line (1- (string-to-number line))))
     (ignore-errors
       (and (re-search-forward helm-ag--last-query (line-end-position) t)
-           (goto-char (match-beginning 0))))))
+           ;; `helm-goto-char' exapnds folded headings/outlines if needed
+           (helm-goto-char (match-beginning 0))))))
 
 (defun helm-ag--open-file-with-temp-buffer (filename)
   (let ((search-directory default-directory))


### PR DESCRIPTION
Helm provides `helm-goto-char` and `helm-goto-line` as alternatives to `goto-char` and `goto-line` that expand folded entries (for `org-mode`, `outline-mode` and `outline-minor-mode`).

Solves #303