### PR TITLE
Add double dash for default searched things

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1120,7 +1120,7 @@ Continue searching the parent directory? "))
           :input (let ((input (or (helm-ag--marked-input t)
                                   (helm-ag--insert-thing-at-point helm-ag-insert-at-point))))
                    (if (string-prefix-p "-" input)
-                       (concatenate 'string "-- " input)
+                       (concat "-- " input)
                      input))
           :history 'helm-ag--helm-history)))
 

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1117,8 +1117,11 @@ Continue searching the parent directory? "))
     (helm-attrset 'name (helm-ag--helm-header search-dir)
                   helm-source-do-ag)
     (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*" :keymap helm-do-ag-map
-          :input (or (helm-ag--marked-input t)
-                     (helm-ag--insert-thing-at-point helm-ag-insert-at-point))
+          :input (let ((input (or (helm-ag--marked-input t)
+                                  (helm-ag--insert-thing-at-point helm-ag-insert-at-point))))
+                   (if (string-prefix-p "-" input)
+                       (concatenate 'string "-- " input)
+                     input))
           :history 'helm-ag--helm-history)))
 
 ;;;###autoload


### PR DESCRIPTION
I found myself using this package (via `(projectile-helm-ag)`) a lot.
However, I very often have a need to search for symbols that start
with `-`. And I use `(thing-at-point)` method to get the string. Without
this commit this results in

```
Candidates function ‘helm-ag--do-ag-candidate-process’ should run a process
```

I decided to fix that by preppending the search term, being it a selected text
or `(thing-at-point)`, with `--` to follow what is in readme.

Run tests from the `test-util.el` - they all pass. Quickly skimming the file
I haven't seen anything targeted to `(helm-do-ag)` nor `(helm-do-ag--helm)`.