### PR TITLE
Handle "partial success" exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,12 @@ I think the searching tool which supports grep like output, helm-ag can work wit
 
 #### [ripgrep](https://github.com/BurntSushi/ripgrep/)
 
+Ripgrep uses exit-status 2 to indicate a partial success:
+
 ```lisp
 (custom-set-variables
- '(helm-ag-base-command "rg --no-heading"))
+ '(helm-ag-base-command "rg --no-heading")
+ `(helm-ag-success-exit-status '(0 2)))
 ```
 
 #### NOTE: For pt and rg users

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -61,6 +61,12 @@
   "Command line option of `ag'. This is appended after `helm-ag-base-command'"
   :type 'string)
 
+(defcustom helm-ag-success-exit-status nil
+  "Allows specifying the return code or codes of
+  `helm-ag-base-command' that will be treated as successful."
+  :type '(choice integer
+                 (list integer)))
+
 (defcustom helm-ag-insert-at-point nil
   "Insert thing at point as search pattern.
    You can set value same as `thing-at-point'"
@@ -265,7 +271,8 @@ Default behaviour shows finish and result in mode-line."
         (replace-match (abbreviate-file-name (match-string-no-properties 1)))))))
 
 (defun helm-ag--command-succeeded-p (cmd exit-status)
-  (cond ((string= cmd "rg") (member exit-status '(0 2))) ;; add more commands if necessary
+  (cond ((integerp helm-ag-success-exit-status) (= exit-status helm-ag-success-exit-status))
+        ((listp helm-ag-success-exit-status) (member exit-status helm-ag-success-exit-status))
         (t (zerop exit-status))))
 
 (defun helm-ag--init ()

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -278,7 +278,7 @@ Default behaviour shows finish and result in mode-line."
         (let ((ret (apply #'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
               (error "No ag output: '%s'" helm-ag--last-query)
-            (unless (zerop ret)
+            (unless (memq ret '(0 2))
               (unless (executable-find (car cmds))
                 (error "'ag' is not installed."))
               (error "Failed: '%s'" helm-ag--last-query))))


### PR DESCRIPTION
Grep, ripgrep, probably others will use an exit status of 2 if there
was output, but a non-fatal error was encountered (for example,
attempting to access a file).

See BurntSushi/ripgrep#1278 for the motivation behind this one.  I'm using helm-ag with ripgrep, and there's a corner-case on windows I'm encountering where certain inaccessible files are being searched, resulting in an error.  This means that there is the expected search output, but because ripgrep (now) respects grep exit-code behaviour it returns 2, and helm-ag therefore tells you there was no output.

I can `(setq helm-ag-base-command "rg --no-messages --smart-case --no-heading --line-number")` (the `--no-messages` argument means no "soft" error messages will be output, just the search results), but the exit status still needs to be handled by helm-ag.