### PR TITLE
Fix helm-ag bug for multiple command line options.

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -178,7 +178,7 @@ Default behaviour shows finish and result in mode-line."
       (when (re-search-forward "\\s-*--\\s-+" nil t)
         (setq end (match-end 0)))
       (goto-char (point-min))
-      (while (re-search-forward "\\(?:^\\|\\s-+\\)\\(-\\S-+\\)\\(?:\\s-+\\|$\\)" end t)
+      (while (re-search-forward "\\(?:\\=\\|\\s-+\\)\\(-\\S-+\\)\\(?:\\s-+\\|$\\)" end t)
         (push (match-string-no-properties 1) options)
         (when end
           (cl-decf end (- (match-end 0) (match-beginning 0))))

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -34,7 +34,14 @@
     (should (equal got '("--nogroup" "--column" "foo bar"))))
 
   (let ((got (helm-ag--parse-query "--column helm-ag ()")))
-    (should (equal got '("--column" "helm-ag ()")))))
+    (should (equal got '("--column" "helm-ag ()"))))
+
+  (let ((got (helm-ag--parse-query "hello -a -b")))
+    (should (equal got '("-a" "-b" "hello"))))
+
+  (let ((got (helm-ag--parse-query "foo bar -g=*.el -g=!test")))
+    (should (equal got '("-g=*.el" "-g=!test" "foo bar"))))
+  )
 
 (ert-deftest construct-command ()
   "helm-ag--construct--command"


### PR DESCRIPTION
This is a simple bugfix. The original function that splits the query into the query and the options will not work with multiple options if there is anything that is not an option before it (i.e. if you wanted to write a query, and then refine what files it's operating on afterwards.)

Here is an example of the fixed function and the old behaviour (fixed is the one prefixed `fixed`).

```
(print (fixed--parse-options-and-query "hello -g world -g"))
; (("-g" "-g") . "hello world")
(print (helm-ag--parse-options-and-query "hello -g world -g"))
; (("-g" "-g") . "helloworld")

(print (fixed--parse-options-and-query "hello -g -g"))
;; (("-g" "-g") . "hello")
(print (helm-ag--parse-options-and-query "hello -g -g"))
;; (("-g") . "hello-g")
```