### PR TITLE
travis: remove travis badge and update env to support from emacs-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: generic
 sudo: false
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-  - evm install $EVM_EMACS --use --skip
-  - cask
 env:
-  - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-26.1-travis-linux-xenial
+  - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 script:
+  - evm install $EVM_EMACS --use --skip
   - emacs --version
+  - cask install
   - make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # helm-ag.el
 
-[![travis badge][travis-badge]][travis-link] [![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
+[![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link]
 
 
 ## Introduction
@@ -293,8 +293,6 @@ So using `pt` or `rg` behaves differently from `ag` when you use such pattern.
 [ag.el](https://github.com/Wilfred/ag.el) provides `M-x grep` interface.
 Also it can work without helm.
 
-[travis-badge]: https://travis-ci.org/syohex/emacs-helm-ag.svg
-[travis-link]: https://travis-ci.org/syohex/emacs-helm-ag
 [melpa-link]: https://melpa.org/#/helm-ag
 [melpa-stable-link]: https://stable.melpa.org/#/helm-ag
 [melpa-badge]: https://melpa.org/packages/helm-ag-badge.svg

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -5,7 +5,7 @@
 ;; Author: Syohei YOSHIDA <syohex@gmail.com>
 ;; URL: https://github.com/syohex/emacs-helm-ag
 ;; Version: 0.59
-;; Package-Requires: ((emacs "24.4") (helm "2.0"))
+;; Package-Requires: ((emacs "25.1") (helm "2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Remove travis badge since it's obsoleted and pointed to old repository. Moreover, since Github support show status now by default, the badge is not needed anymore.

Also, since `emacs-24` is old (> 8 years) and continuously failing build, we should just upgrade to support from `emacs-25`.