### PR TITLE
feat: add helm-do-ag-this-file-or-occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ You can specify extra command line option of `ag` with minus prefix(`M--` or `C-
 
 Same as `helm-do-ag` except to search only current file
 
+##### `helm-do-ag-this-file-or-occur`
+
+Smartly switch between `helm-do-ag-this-file` and `helm-occur` based on `helm-ag-large-file-threshold`.
+
 ##### `helm-ag-project-root`
 
 Call `helm-ag` at project root. `helm-ag` seems directory as project root where

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -168,13 +168,16 @@
 
 (ert-deftest transform-for-this-file ()
   "helm-ag--candidate-transform-for-this-file"
-  (let ((helm-ag--last-query "hoge"))
+  (let ((helm-ag--last-command `("ag" "--nogroup"))
+        (helm-ag--search-this-file-p t)
+        (helm-ag--last-query "hoge"))
     (should (helm-ag--candidate-transform-for-this-file "10:hoge"))
     (should-not (helm-ag--candidate-transform-for-this-file ":hoge"))))
 
 (ert-deftest transform-for-files ()
   "helm-ag--candidate-transform-for-files"
-  (let ((helm-ag--last-query "hoge"))
+  (let ((helm-ag--last-command `("ag" "--nogroup"))
+        (helm-ag--last-query "hoge"))
     (should (helm-ag--candidate-transform-for-files "10:5:hoge"))
     (should-not (helm-ag--candidate-transform-for-files "10:hoge"))))
 
@@ -258,11 +261,6 @@
     (should (equal (helm-ag--join-patterns "foo !bar") "(?=.*foo.*)(?=^(?!.*bar).+$)"))))
 
 (ert-deftest search-this-file-p ()
-  "Ag does not show file name at searching only one file except '--vimgrep'
-option specified"
-  (let ((helm-ag--last-command '("--vimgrep")))
-    (should-not (helm-ag--search-this-file-p)))
-
   (cl-letf (((symbol-function 'helm-get-current-source)
              (lambda () 'helm-source-ag))
             ((symbol-function 'helm-attr)


### PR DESCRIPTION
Add `helm-do-ag-this-file-or-occur` which will smartly switch between `helm-occur` or `helm-do-ag-this-file` depends on `helm-ag-large-file-threshold`.

I need to remove several Windows checks (why we need that in the first place???) and several vim-grep check to archive same interface between `helm-occur` and `helm-do-ag-this-file`.
Thus, the large PR. However, most of them are just removing the checks.

Here is how it's in action:
![3fd85565-e84d-4bc9-9915-d819a10108c4](https://user-images.githubusercontent.com/2631472/77813127-6b69ad00-70e9-11ea-9744-b522b1ba5726.gif)
