### PR TITLE
Check --pcre2 option for ripgrep

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1202,7 +1202,9 @@ Continue searching the parent directory? "))
       (rg (add-to-list 'helm-ag--command-features
                        (if (string-match-p "-\\(?:F\\|-fixed-strings\\)\\>" helm-ag-base-command)
                            'fixed
-                         're2))))))
+                         (if (string-match-p "--pcre2\\>" helm-ag-base-command)
+                             'pcre
+                           're2)))))))
 
 (defun helm-ag--do-ag-searched-extensions ()
   "Not documented."


### PR DESCRIPTION
We can use `pcre` on `ripgrep` if `ripgrep` is built with `pcre2` feature flag and use `--pcre2` command line flag. Then we can use negate match feature(`!pattern`) of helm-ag as below.

![ripgrep-pcre2](https://user-images.githubusercontent.com/554281/78565422-e2751300-7858-11ea-9e74-30c197b9f02c.gif)

```lisp
(setq helm-ag-base-command "rg --no-heading --pcre2 --color=never --vimgrep")
```
