### PR TITLE
Load helm-occur for using face

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -35,6 +35,7 @@
 (require 'cl-lib)
 (require 'helm)
 (require 'helm-grep)
+(require 'helm-occur)
 (require 'helm-utils)
 (require 'compile)
 (require 'subr-x)


### PR DESCRIPTION
Original code does not highlight filename until helm-occur is loaded

![helm-ag-face](https://user-images.githubusercontent.com/554281/81467947-1d32e800-9217-11ea-8f0a-1dd1f8fb649e.png)


