### PR TITLE
Fix "Failed: ’XXX’" when helm-ag-success-exit-status is nil

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -301,7 +301,7 @@ Default behaviour shows finish and result in mode-line."
 
 (defun helm-ag--command-succeeded-p (cmd exit-status)
   (cond ((integerp helm-ag-success-exit-status) (= exit-status helm-ag-success-exit-status))
-        ((listp helm-ag-success-exit-status) (member exit-status helm-ag-success-exit-status))
+        ((consp helm-ag-success-exit-status) (member exit-status helm-ag-success-exit-status))
         (t (zerop exit-status))))
 
 (defun helm-ag--init ()


### PR DESCRIPTION
The `helm-ag--command-succeeded-p` use `listp` inside not work as expected:

```elisp
(let ((helm-ag-success-exit-status nil))
  (helm-ag--command-succeeded-p nil 0))
;; => nil (expected t)
```

The `listp` should be replaced with `consp`:

```elisp
(listp nil)     ;; => t
(consp nil)     ;; => nil
```
