### PR TITLE
Fix helm-ag persistent action highlight issue

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -390,9 +390,13 @@ Default behaviour shows finish and result in mode-line."
   "Not documented, CANDIDATE."
   (let ((find-func (if helm-ag-use-temp-buffer
                        #'helm-ag--open-file-with-temp-buffer
-                     #'find-file)))
+                     #'find-file))
+        (helm-ag-p (assoc-default 'real-to-display (helm-get-current-source))))
     (helm-ag--find-file-action candidate find-func (helm-ag--search-this-file-p) t)
-    (helm-highlight-current-line)))
+    (let ((helm-input (if helm-ag-p
+                          (concat helm-ag--last-query " " helm-input)
+                        helm-input)))
+      (helm-highlight-current-line))))
 
 (defun helm-ag--validate-regexp (regexp)
   "Not documented, REGEXP."


### PR DESCRIPTION
#### Original implementation
This does not highlight search word

![before](https://user-images.githubusercontent.com/554281/83139015-a8244580-a126-11ea-997f-c7cbf33fec4e.gif)

#### This PR version

![after](https://user-images.githubusercontent.com/554281/83139030-afe3ea00-a126-11ea-8142-790073613061.gif)

This is related to #360 (CC: @taquangtrung)
