### PR TITLE
Allow candidates marking

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1220,7 +1220,7 @@ Continue searching the parent directory? "))
    (candidate-number-limit :initform 99999)
    (requires-pattern :initform 3)
    (persistent-action :initform 'helm-ag--persistent-action)
-   (nomark :initform t)
+   (nomark :initform nil)
    (action :initform 'helm-ag--actions))
   "Not documented.")
 


### PR DESCRIPTION
The PR allows us to mark candidates in `helm-ag`, which is the behavior before this change: [ Add syohex's patch for incremental coloring ](https://github.com/emacsorphanage/helm-ag/commit/29d633643d1bb324a7c578aafa2b9caac3070043)

Example use case:  mark candidates and then do `helm-ag-edit` on them.