### PR TITLE
Clear extra option if it is not set

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1259,11 +1259,12 @@ Continue searching the parent directory? "))
 
 (defun helm-ag--set-do-ag-option ()
   "Not documented."
-  (when (or (< (prefix-numeric-value current-prefix-arg) 0)
-            helm-ag-always-set-extra-option)
-    (let ((option (read-string "Extra options: " (or helm-ag--extra-options "")
-                               'helm-ag--extra-options-history)))
-      (setq helm-ag--extra-options option))))
+  (if (or (< (prefix-numeric-value current-prefix-arg) 0)
+          helm-ag-always-set-extra-option)
+      (let ((option (read-string "Extra options: " (or helm-ag--extra-options "")
+                                 'helm-ag--extra-options-history)))
+        (setq helm-ag--extra-options option))
+    (setq helm-ag--extra-options nil)))
 
 (defun helm-ag--set-command-features ()
   "Not documented."


### PR DESCRIPTION
#### How to reproduce issue with original code

1. `C-- M-x helm-do-ag` (minus prefix)
2. Set extra argument like `-G\.md`
3. `M-x helm-do-ag` 
4.  This `helm-do-ag` does not set extra argument, but the option which was set previous invocation is specified