### PR TITLE
Travis CI covers Emac 27 with Nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # https://github.com/purcell/nix-emacs-ci
 language: nix
+sudo: false
 cache:
   directories:
   - $HOME/nix.store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,59 @@
-language: generic
-sudo: false
+# https://github.com/purcell/nix-emacs-ci
+language: nix
+cache:
+  directories:
+  - $HOME/nix.store
+
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-2
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-2
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-27-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-snapshot
+
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-env:
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-26.1-travis-linux-xenial
-  - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
+  - sudo mkdir -p /etc/nix
+  - echo "substituters = https://cache.nixos.org/ file://$HOME/nix.store" | sudo tee -a /etc/nix/nix.conf > /dev/null
+  - echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
+
+before_cache:
+  - mkdir -p $HOME/nix.store
+  - nix copy --to file://$HOME/nix.store -f default.nix buildInputs
+
+install:
+  # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
+  - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
+  - export PATH=$HOME/.cask/bin:$PATH
+  - travis_retry eval $"cask install ; sleep 10"
+
 script:
-  - evm install $EVM_EMACS --use --skip
+  - export PATH=$HOME/.cask/bin:$PATH
   - emacs --version
-  - cask install
+  - cask build
   - make test
+
+allow_failures:
+  - os: linux
+    dist: bionic
+    env: EMACS_CI=emacs-snapshot


### PR DESCRIPTION
As far as I know, EVM does not provide Emacs 27: https://github.com/rejeep/evm

This PR replaces the usage of EVM with Nix, using these instructions: https://github.com/purcell/nix-emacs-ci

I've successfully made these changes in git-link (https://github.com/sshaw/git-link/pull/74) and Helm (https://github.com/emacs-helm/helm/pull/2366).

As far as I know, `make test` should run exactly as before with these changes.

With this PR, Travis CI would cover Emacs 25.1-3, 26.1-3 and 27.1