### PR TITLE
Unmark the temporary buffer for preview as modified

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -371,6 +371,7 @@ Default behaviour shows finish and result in mode-line."
     (fundamental-mode)
     (erase-buffer)
     (insert-file-contents filename)
+    (set-buffer-modified-p nil)
     (let ((buffer-file-name filename))
       (set-auto-mode)
       (font-lock-fontify-region (point-min) (point-max)))))


### PR DESCRIPTION
This fixes two annoying problems.

- When `set-auto-mode` is called with a buffer marked as modified, some minor modes that conditionally call `revert-buffer` result in generating a user prompt while navigating through helm candidates.

  `editorconfig-mode` is one of such modes.  `editorconfig-apply` is called via `change-major-mode-after-body-hook` and tries to enforce the coding system specified by the project via `revert-buffer-with-coding-system`, which generates a yes-or-no-p prompt asking "Revert buffer from file <filename>?".

- Persistent undo history for the file is affected and broken when using packages like `undohist` and `undo-fu-session`.
