### PR TITLE
restored two lines removed earlier

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1135,7 +1135,9 @@ Continue searching the parent directory? "))
            proc
            (lambda (process event)
              (helm-process-deferred-sentinel-hook
-              process event (helm-default-directory)))))))))
+              process event (helm-default-directory))
+             (when (string= event "finished\n")
+               (helm-ag--do-ag-propertize helm-input)))))))))
 
 (defconst helm-do-ag--help-message
   "\n* Helm Do Ag\n


### PR DESCRIPTION
This restores two lines that were removed on May 6, 2020 via https://github.com/emacsorphanage/helm-ag/commit/29d633643d1bb324a7c578aafa2b9caac3070043 which I presume was accidental.  Lines 1114 and 1115 are the lines of interest.

The restored lines signal that the search is done so that this can be used to for example to add "(DONE)" string on mode line as detailed at https://github.com/syl20bnr/spacemacs/issues/14455.

@alexey0308 discovered that the May 6 change dropped the two lines being restored by this PR.