### PR TITLE
Make sure the temp buffer for the persistent action is not read-only

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -367,7 +367,8 @@ Default behaviour shows finish and result in mode-line."
   "Not documented, FILENAME."
   (let ((search-directory default-directory))
     (switch-to-buffer (get-buffer-create " *helm-ag persistent*"))
-    (setq default-directory search-directory)
+    (setq default-directory search-directory
+          buffer-read-only nil)
     (fundamental-mode)
     (erase-buffer)
     (insert-file-contents filename)


### PR DESCRIPTION
While previewing the file corresponding to a search result in a temporary
buffer (`helm-ag-use-temp-buffer` is set to `t`), it can happen that the file's
mode makes the temporary buffer read-only. For example, when `so-long-mode`
kicks in.

When then trying to preview a search result from another file,
`helm-ag--open-file-with-temp-buffer` will fail to erase the temporary buffer
because it is in read-only mode, resulting in:

    let: Buffer is read-only: #<buffer  *helm-ag persistent*>

Fix this by explicitly setting the `buffer-read-only` variable of the temporary
buffer to `nil` before erasing it.
