### PR TITLE
Skip read-only Filenames in helm-ag-edit Buffers

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -758,6 +758,7 @@ Default behaviour shows finish and result in mode-line."
   (goto-char (point-min))
   (setq next-error-function 'compilation-next-error-function)
   (setq-local compilation-locs (make-hash-table :test 'equal :weakness 'value))
+  (setq-local query-replace-skip-read-only t)
   (use-local-map helm-ag-edit-map))
 
 (defun helm-ag-edit ()


### PR DESCRIPTION
Hi, this PR makes it so that filenames are ignored in `helm-ag-edit` buffers when using `query-replace`.

This is done by setting `query-replace-skip-read-only` to `t` as a local variable in `helm-ag-edit` buffers, so that it does not affect the existing global value of `query-replace-skip-read-only`.