### PR TITLE
Always update status if search process ends

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1058,10 +1058,7 @@ Continue searching the parent directory? "))
    (helm-ag--remove-carrige-returns)
    (when helm-ag--buffer-search
      (helm-ag--abbreviate-file-name))
-   (helm-ag--propertize-candidates input)
-   (when helm-ag-show-status-function
-     (funcall helm-ag-show-status-function)
-     (force-mode-line-update))))
+   (helm-ag--propertize-candidates input)))
 
 (defun helm-ag--construct-extension-options ()
   "Not documented."
@@ -1138,7 +1135,13 @@ Continue searching the parent directory? "))
              (helm-process-deferred-sentinel-hook
               process event (helm-default-directory))
              (when (string= event "finished\n")
-               (helm-ag--do-ag-propertize helm-input)))))))))
+               (helm-ag--do-ag-propertize helm-input))
+             ;; Always update status to inform user if process ends
+             (when (and helm-ag-show-status-function
+                        (not (process-live-p process)))
+               (with-helm-window
+                 (funcall helm-ag-show-status-function)
+                 (force-mode-line-update))))))))))
 
 (defconst helm-do-ag--help-message
   "\n* Helm Do Ag\n


### PR DESCRIPTION
If the search process ends with a non-zero exit code, the helm status was never updated. E.g. Grep, Ripgrep and likely more use exit code 1 to indicate that nothing is found, a frequently occurring scenario that left the user wondering if the process is still searching or not.

Now it will always update status if the process is not live anymore.

Fixes #251 (not by adding a waiting status as suggested, but clearly indicating the finished status)