### PR TITLE
Further Support "rg" Backend

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -133,6 +133,7 @@ Default behaviour shows finish and result in mode-line."
   '((t (:inherit font-lock-comment-face :strike-through t)))
   "Face of deleted line in edit mode.")
 
+(defvar helm-ag--command nil)
 (defvar helm-ag--command-history '())
 (defvar helm-ag--helm-history '())
 (defvar helm-ag--context-stack nil)
@@ -169,16 +170,16 @@ Default behaviour shows finish and result in mode-line."
 (defun helm-ag--save-current-context ()
   "Not documented."
   (let ((curpoint (with-helm-current-buffer
-                   (point))))
+                    (point))))
     (helm-aif (buffer-file-name helm-current-buffer)
-              (push (list :file it :point curpoint) helm-ag--context-stack)
-              (push (list :buffer helm-current-buffer :point curpoint) helm-ag--context-stack))))
+        (push (list :file it :point curpoint) helm-ag--context-stack)
+      (push (list :buffer helm-current-buffer :point curpoint) helm-ag--context-stack))))
 
 (defun helm-ag--insert-thing-at-point (thing)
   "Not documented, THING."
   (helm-aif (thing-at-point thing)
-            (substring-no-properties it)
-            ""))
+      (substring-no-properties it)
+    ""))
 
 (defun helm-ag--searched-word ()
   "Not documented."
@@ -188,7 +189,9 @@ Default behaviour shows finish and result in mode-line."
 
 (defun helm-ag--construct-ignore-option (pattern)
   "Not documented, PATTERN."
-  (concat "--ignore=" pattern))
+  (cl-case helm-ag--command
+    (ag (concat "--ignore=" pattern))
+    (rg (concat "--glob=!" pattern))))
 
 (defun helm-ag--grep-ignore-list-to-options ()
   "Not documented."
@@ -250,25 +253,37 @@ Default behaviour shows finish and result in mode-line."
     (cl-loop for target in targets
              collect (file-relative-name target))))
 
-(defun helm-ag--root-agignore ()
+(defun helm-ag--ignore-file-option ()
   "Not documented."
   (let ((root (helm-ag--project-root)))
     (when root
       (let ((default-directory root))
-        (when (file-exists-p ".agignore")
-          (expand-file-name (concat default-directory ".agignore")))))))
+        (cl-case helm-ag--command
+          (ag (when (file-exists-p ".agignore")
+                (list '--path-to-ignore'
+                      expand-file-name (concat default-directory ".agignore"))))
+          (rg (when (file-exits-p ".rgignore")
+                (list '--ignore-file'
+                      (expend-file-name (concat default-directory ".rgignore"))))))))))
 
 (defun helm-ag--construct-command (this-file)
   "Not documented, THIS-FILE."
   (let* ((commands (split-string helm-ag-base-command nil t))
          (command (car commands))
          (args (cdr commands)))
+    (cl-case (intern command)
+      (ag (setq helm-ag--command 'ag))
+      (rg (setq helm-ag--command 'rg))
+      (pt (setq helm-ag--command 'pt))
+      (ack (setq helm-ag--command 'ack))
+      (t (error (format "Error: grep command %s is not supported,
+please use ag, rg, pt or ack" command))))
     (when helm-ag-command-option
       (let ((ag-options (split-string helm-ag-command-option nil t)))
         (setq args (append args ag-options))))
-    (when helm-ag-use-agignore
-      (helm-aif (helm-ag--root-agignore)
-                (setq args (append args (list "-p" it)))))
+    (when helm-ag--extra-options
+      (setq args (append args (split-string helm-ag--extra-options))))
+    (setq args (append args (helm-ag--ignore-file-option)))
     (when helm-ag-ignore-patterns
       (setq args (append args (mapcar 'helm-ag--construct-ignore-option
                                       helm-ag-ignore-patterns))))
@@ -277,11 +292,11 @@ Default behaviour shows finish and result in mode-line."
     (setq args (append args (helm-ag--parse-query helm-ag--last-query)))
     (when this-file
       (setq args (append args (list this-file))))
-    (when helm-ag--buffer-search
-      (setq args (append args (helm-ag--file-visited-buffers))))
-    (when helm-ag--default-target
-      (setq args (append args (helm-ag--construct-targets helm-ag--default-target))))
-    (cons command args)))
+  (when helm-ag--buffer-search
+    (setq args (append args (helm-ag--file-visited-buffers))))
+  (when helm-ag--default-target
+    (setq args (append args (helm-ag--construct-targets helm-ag--default-target))))
+  (cons command args)))
 
 (defun helm-ag--remove-carrige-returns ()
   "Not documented."
@@ -309,11 +324,11 @@ Default behaviour shows finish and result in mode-line."
 (defun helm-ag--init ()
   "Not documented."
   (let ((buf-coding buffer-file-coding-system))
-    (helm-attrset 'recenter t)
+    (helm-set-attr 'recenter t)
     (with-current-buffer (helm-candidate-buffer 'global)
       (let* ((default-directory (or helm-ag--default-directory
                                     default-directory))
-             (cmds (helm-ag--construct-command (helm-attr 'search-this-file)))
+             (cmds (helm-ag--construct-command (helm-get-attr 'search-this-file)))
              (coding-system-for-read buf-coding)
              (coding-system-for-write buf-coding))
         (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmds helm-ag--last-query)
@@ -385,7 +400,7 @@ Default behaviour shows finish and result in mode-line."
   (unless (helm-ag--vimgrep-option)
     (if (eq (helm-get-current-source) 'helm-source-do-ag)
         (helm-ag--search-only-one-file-p)
-      (helm-attr 'search-this-file))))
+      (helm-get-attr 'search-this-file))))
 
 (defun helm-ag--persistent-action (candidate)
   "Not documented, CANDIDATE."
@@ -470,14 +485,14 @@ Default behaviour shows finish and result in mode-line."
 (defun helm-ag--candidate-transform-for-files (candidate)
   "Not documented, CANDIDATE."
   (helm-aif (helm-grep-split-line candidate)
-            (format "%s:%s:%s"
-                    (propertize (cl-first it) 'face 'helm-moccur-buffer)
-                    (propertize (cl-second it) 'face 'helm-grep-lineno)
-                    (helm-ag--highlight-candidate (cl-third it)))))
+      (format "%s:%s:%s"
+              (propertize (cl-first it) 'face 'helm-moccur-buffer)
+              (propertize (cl-second it) 'face 'helm-grep-lineno)
+              (helm-ag--highlight-candidate (cl-third it)))))
 
 (defun helm-ag--candidate-transformer (candidate)
   "Not documented, CANDIDATE."
-  (or (if (helm-attr 'search-this-file)
+  (or (if (helm-get-attr 'search-this-file)
           (helm-ag--candidate-transform-for-this-file candidate)
         (helm-ag--candidate-transform-for-files candidate))
       candidate))
@@ -515,14 +530,14 @@ Default behaviour shows finish and result in mode-line."
 
 (defvar helm-ag-source
   (helm-build-in-buffer-source "The Silver Searcher"
-                               :init 'helm-ag--init
-                               :real-to-display 'helm-ag--candidate-transformer
-                               :persistent-action 'helm-ag--persistent-action
-                               :fuzzy-match helm-ag-fuzzy-match
-                               :action helm-ag--actions
-                               :candidate-number-limit 9999
-                               :keymap helm-ag-map
-                               :follow (and helm-follow-mode-persistent 1))
+    :init 'helm-ag--init
+    :real-to-display 'helm-ag--candidate-transformer
+    :persistent-action 'helm-ag--persistent-action
+    :fuzzy-match helm-ag-fuzzy-match
+    :action helm-ag--actions
+    :candidate-number-limit 9999
+    :keymap helm-ag-map
+    :follow (and helm-follow-mode-persistent 1))
   "Not documented.")
 
 ;;;###autoload
@@ -533,11 +548,11 @@ Default behaviour shows finish and result in mode-line."
     (unless context
       (error "Context stack is empty !"))
     (helm-aif (plist-get context :file)
-              (find-file it)
-              (let ((buf (plist-get context :buffer)))
-                (if (buffer-live-p buf)
-                    (switch-to-buffer buf)
-                  (error "The buffer is already killed"))))
+        (find-file it)
+      (let ((buf (plist-get context :buffer)))
+        (if (buffer-live-p buf)
+            (switch-to-buffer buf)
+          (error "The buffer is already killed"))))
     (goto-char (plist-get context :point))))
 
 ;;;###autoload
@@ -566,7 +581,7 @@ Default behaviour shows finish and result in mode-line."
                                           nil
                                           'helm-ag--command-history
                                           (helm-aif (symbol-at-point)
-                                                    (symbol-name it))))))
+                                              (symbol-name it))))))
     (when (string-empty-p query)
       (error "Input is empty!!"))
     (setq helm-ag--last-query query)))
@@ -599,7 +614,7 @@ Default behaviour shows finish and result in mode-line."
   "Not documented."
   (interactive)
   (with-helm-alive-p
-   (helm-exit-and-execute-action #'helm-ag--action-find-file-other-window)))
+    (helm-exit-and-execute-action #'helm-ag--action-find-file-other-window)))
 
 (defun helm-ag--exit-from-edit-mode ()
   "Not documented."
@@ -867,9 +882,9 @@ Special commands:
   (interactive)
   (let ((use-other-buf-p current-prefix-arg))
     (with-helm-alive-p
-     (helm-exit-and-execute-action
-      (lambda (_arg)
-        (helm-ag--save-results use-other-buf-p))))))
+      (helm-exit-and-execute-action
+       (lambda (_arg)
+         (helm-ag--save-results use-other-buf-p))))))
 
 (defun helm-ag--file-of-current-file ()
   "Not documented."
@@ -880,12 +895,12 @@ Special commands:
 (defun helm-ag--move-file-common (pred move-fn wrap-fn)
   "Not documented, PRED, MOVE-FN, WRAP-FN."
   (with-helm-window
-   (let ((file (helm-ag--file-of-current-file)))
-     (funcall move-fn)
-     (while (and (not (funcall pred)) (string= file (helm-ag--file-of-current-file)))
-       (funcall move-fn))
-     (when (funcall pred)
-       (funcall wrap-fn)))))
+    (let ((file (helm-ag--file-of-current-file)))
+      (funcall move-fn)
+      (while (and (not (funcall pred)) (string= file (helm-ag--file-of-current-file)))
+        (funcall move-fn))
+      (when (funcall pred)
+        (funcall wrap-fn)))))
 
 (defun helm-ag--previous-file ()
   "Not documented."
@@ -916,7 +931,7 @@ Continue searching the parent directory? "))
            (let* ((default-directory parent)
                   (helm-ag--default-directory parent))
              (setq helm-ag--last-default-directory default-directory)
-             (helm-attrset 'name (helm-ag--helm-header default-directory) helm-ag-source)
+             (helm-set-attr 'name (helm-ag--helm-header default-directory) helm-ag-source)
              (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map
                    :history 'helm-ag--helm-history)))))
     (message nil)))
@@ -930,9 +945,9 @@ Continue searching the parent directory? "))
         (helm-ag--default-directory default-directory))
     (helm-ag--query query)
     (helm-ag--set-command-features)
-    (helm-attrset 'search-this-file (file-relative-name (buffer-file-name))
-                  helm-ag-source)
-    (helm-attrset 'name (format "Search at %s" filename) helm-ag-source)
+    (helm-set-attr 'search-this-file (file-relative-name (buffer-file-name))
+                   helm-ag-source)
+    (helm-set-attr 'name (format "Search at %s" filename) helm-ag-source)
     (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map
           :history 'helm-ag--helm-history)))
 
@@ -949,8 +964,9 @@ Continue searching the parent directory? "))
     (let ((helm-ag--default-directory (or basedir dir))
           (helm-ag--default-target targets))
       (helm-ag--query query)
-      (helm-attrset 'search-this-file nil helm-ag-source)
-      (helm-attrset 'name (helm-ag--helm-header helm-ag--default-directory) helm-ag-source)
+      (helm-ag--set-command-features)
+      (helm-set-attr 'search-this-file nil helm-ag-source)
+      (helm-set-attr 'name (helm-ag--helm-header helm-ag--default-directory) helm-ag-source)
       (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map
             :history 'helm-ag--helm-history))))
 
@@ -1055,30 +1071,33 @@ Continue searching the parent directory? "))
 (defun helm-ag--do-ag-propertize (input)
   "Not documented, INPUT."
   (with-helm-window
-   (helm-ag--remove-carrige-returns)
-   (when helm-ag--buffer-search
-     (helm-ag--abbreviate-file-name))
-   (helm-ag--propertize-candidates input)
-   (when helm-ag-show-status-function
-     (funcall helm-ag-show-status-function)
-     (force-mode-line-update))))
+    (helm-ag--remove-carrige-returns)
+    (when helm-ag--buffer-search
+      (helm-ag--abbreviate-file-name))
+    (helm-ag--propertize-candidates input)
+    (when helm-ag-show-status-function
+      (funcall helm-ag-show-status-function)
+      (force-mode-line-update))))
 
 (defun helm-ag--construct-extension-options ()
   "Not documented."
   (cl-loop for ext in helm-do-ag--extensions
            unless (string= ext "*")
            collect
-           (concat "-G" (replace-regexp-in-string
-                         "\\*" ""
-                         (replace-regexp-in-string "\\." "\\\\." ext)))))
+           (cl-case helm-ag--command
+             (ag (concat "--file-search-regex" (replace-regexp-in-string
+                                                "\\*" ""
+                                                (replace-regexp-in-string "\\." "\\\\." ext))))
+             (rg (concat "--glob=" (replace-regexp-in-string "\\." "\\\\." ext))))))
 
 (defun helm-ag--show-result-p (options has-query)
   "Not documented, OPTIONS, HAS-QUERY."
   (or has-query
-      (cl-loop for opt in options
-               thereis (string-prefix-p "-g" opt))))
+      (when (eq helm-ag--command 'ag)
+        (cl-loop for opt in options
+                 thereis (string-prefix-p "-g" opt)))))
 
-(defun helm-ag--construct-do-ag-command (pattern)
+(defun helm-ag--construct-do-ag-command (pattern &optional this-file)
   "Not documented, PATTERN."
   (let* ((opt-query (helm-ag--parse-options-and-query pattern))
          (options (car opt-query))
@@ -1087,44 +1106,18 @@ Continue searching the parent directory? "))
     (when helm-ag-use-emacs-lisp-regexp
       (setq query (helm-ag--elisp-regexp-to-pcre query)))
     (when (helm-ag--show-result-p options has-query)
-      (append (car helm-do-ag--commands)
-              options
-              (and has-query (list (helm-ag--join-patterns query)))
-              (cdr helm-do-ag--commands)))))
-
-(defun helm-ag--do-ag-set-command ()
-  "Not documented."
-  (let ((cmd-opts (split-string helm-ag-base-command nil t)))
-    (when helm-ag-command-option
-      (setq cmd-opts (append cmd-opts (split-string helm-ag-command-option nil t))))
-    (when helm-ag--extra-options
-      (setq cmd-opts (append cmd-opts (split-string helm-ag--extra-options))))
-    (when helm-ag-ignore-patterns
-      (setq cmd-opts
-            (append cmd-opts
-                    (mapcar #'helm-ag--construct-ignore-option
-                            helm-ag-ignore-patterns))))
-    (when helm-ag-use-agignore
-      (helm-aif (helm-ag--root-agignore)
-                (setq cmd-opts (append cmd-opts (list "-p" it)))))
-    (when helm-do-ag--extensions
-      (setq cmd-opts (append cmd-opts (helm-ag--construct-extension-options))))
-    (when helm-ag-use-grep-ignore-list
-      (setq cmd-opts (append cmd-opts (helm-ag--grep-ignore-list-to-options))))
-    (let (targets)
-      (when helm-ag--buffer-search
-        (setq targets (helm-ag--file-visited-buffers)))
-      (setq helm-do-ag--commands
-            (cons cmd-opts
-                  (if helm-ag--default-target
-                      (append targets (helm-ag--construct-targets helm-ag--default-target))
-                    targets))))))
+      (let ((cmds (helm-ag--construct-command this-file))
+           (append (car cmds) ;; command
+                   options ;; options
+                   (and has-query (list (helm-ag--join-patterns query))) ;; patterns
+                   (cdr cmds))))))) ;; paths
 
 (defun helm-ag--do-ag-candidate-process (dir)
   "Not documented, DIR."
   (let* ((non-essential nil)
          (default-directory dir)
-         (cmd-args (helm-ag--construct-do-ag-command helm-pattern)))
+         (this-file (helm-get-attr 'search-this-file))
+         (cmd-args (helm-ag--construct-do-ag-command helm-pattern this-file)))
     (when cmd-args
       (let ((proc (apply #'start-file-process "helm-do-ag" nil cmd-args)))
         (setq helm-ag--last-query helm-pattern
@@ -1236,13 +1229,12 @@ Continue searching the parent directory? "))
   (let ((search-dir (or search-dir dir)))
     (setq helm-source-do-ag
           (helm-make-source "AG" 'helm-do-ag-class
-                            :candidates-process
-                            (lambda ()
-                              (helm-ag--do-ag-set-command)
-                              (helm-ag--do-ag-candidate-process dir))
-                            :header-name
-                            (lambda (_name) (helm-ag--helm-header search-dir))
-                            :follow (and helm-follow-mode-persistent 1)))))
+            :candidates-process
+            (lambda ()
+              (helm-ag--do-ag-candidate-process dir))
+            :header-name
+            (lambda (_name) (helm-ag--helm-header search-dir))
+            :follow (and helm-follow-mode-persistent 1)))))
 
 (defun helm-ag--do-ag-up-one-level ()
   "Not documented."
@@ -1315,7 +1307,7 @@ Continue searching the parent directory? "))
                  helm-ag--last-default-directory
                  default-directory)))
     (helm-ag--do-ag-set-source dir search-dir)
-    (helm-attrset 'search-this-file search-this-file helm-source-do-ag)
+    (helm-set-attr 'search-this-file search-this-file helm-source-do-ag)
     (helm :sources 'helm-source-do-ag :buffer "*helm-ag*" :keymap helm-do-ag-map
           :input (or default-input (helm-ag--marked-input t)
                      (helm-ag--insert-thing-at-point helm-ag-insert-at-point))
@@ -1326,8 +1318,8 @@ Continue searching the parent directory? "))
   "Not documented, QUERY."
   (interactive)
   (helm-aif (buffer-file-name)
-            (helm-do-ag default-directory (list it) query)
-            (error "Error: This buffer is not visited file")))
+      (helm-do-ag default-directory (list it) query)
+    (error "Error: This buffer is not visited file")))
 
 ;;;###autoload
 (defun helm-do-ag (&optional basedir targets default-input)

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -112,7 +112,6 @@
 (ert-deftest construct-do-ag-command ()
   "helm-ag--construct-do-ag-command"
   (let ((helm-ag-base-command "ag --nocolor --nogroup"))
-    (helm-ag--do-ag-set-command)
     (let ((got (helm-ag--construct-do-ag-command "somepattern"))
           (expected '("ag" "--nocolor" "--nogroup" "somepattern")))
       (should (equal got expected)))
@@ -138,14 +137,12 @@
       (should (equal got expected)))
 
     (let ((helm-ag-command-option "--ignore-case --all-text"))
-      (helm-ag--do-ag-set-command)
       (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
              (expected '("ag" "--nocolor" "--nogroup" "--ignore-case" "--all-text"
                          "somepattern")))
         (should (equal got expected))))
 
     (let ((helm-ag-ignore-patterns '("apple" "orange")))
-      (helm-ag--do-ag-set-command)
       (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
              (expected '("ag" "--nocolor" "--nogroup" "--ignore=apple" "--ignore=orange"
                          "somepattern")))
@@ -155,7 +152,6 @@
   "helm-ag--construct-do-ag-command with extra options"
   (let ((helm-ag-base-command "ag --nocolor --nogroup")
         (helm-ag--extra-options "-G\\.md$"))
-    (helm-ag--do-ag-set-command)
     (let ((got (helm-ag--construct-do-ag-command "somepattern"))
           (expected '("ag" "--nocolor" "--nogroup" "-G\\.md$" "somepattern")))
       (should (equal got expected)))))

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -109,51 +109,96 @@
           (expected '("ag" "--nocolor" "--nogroup" "--ignore=*.md" "--ignore=*.el" "foo")))
       (should (equal got expected)))))
 
-(ert-deftest construct-do-ag-command ()
-  "helm-ag--construct-do-ag-command"
-  (let ((helm-ag-base-command "ag --nocolor --nogroup"))
-    (let ((got (helm-ag--construct-do-ag-command "somepattern"))
-          (expected '("ag" "--nocolor" "--nogroup" "somepattern")))
-      (should (equal got expected)))
+(ert-deftest construct-command-in-do-ag ()
+  "helm-ag--construct-command used in helm-do-ag"
+  (let* ((helm-ag-base-command "ag --nocolor --nogroup")
+         (helm-ag--last-query "somepattern")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "somepattern")))
+    (should (equal got expected)))
 
-    (let* ((helm-ag--command-features '())  ;; unknown pattern
-           (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "pat1 pat2")))
-      (should (equal got expected)))
+  (let* ((helm-ag--command-features '())  ;; unknown pattern
+         (helm-ag--last-query "pat1 pat2")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "pat1 pat2")))
+    (should (equal got expected)))
 
-    (let* ((helm-ag--command-features '(fixed))
-           (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "pat1 pat2")))
-      (should (equal got expected)))
+  (let* ((helm-ag--command-features '(fixed))
+         (helm-ag--last-query "pat1 pat2")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "pat1 pat2")))
+    (should (equal got expected)))
 
-    (let* ((helm-ag--command-features '(re2))
-           (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "pat1.*pat2")))
-      (should (equal got expected)))
+  (let* ((helm-ag--command-features '(re2))
+         (helm-ag--last-query "pat1 pat2")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "pat1.*pat2")))
+    (should (equal got expected)))
 
-    (let* ((helm-ag--command-features '(pcre))
-           (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "(?=.*pat1.*)(?=.*pat2.*)")))
-      (should (equal got expected)))
+  (let* ((helm-ag--command-features '(pcre))
+         (helm-ag--last-query "pat1 pat2")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "(?=.*pat1.*)(?=.*pat2.*)")))
+    (should (equal got expected)))
 
-    (let ((helm-ag-command-option "--ignore-case --all-text"))
-      (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
-             (expected '("ag" "--nocolor" "--nogroup" "--ignore-case" "--all-text"
-                         "somepattern")))
-        (should (equal got expected))))
+  (let* ((helm-ag-command-option "--ignore-case --all-text")
+         (helm-ag--last-query "somepattern")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "--ignore-case" "--all-text"
+                     "somepattern")))
+    (should (equal got expected)))
 
-    (let ((helm-ag-ignore-patterns '("apple" "orange")))
-      (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
-             (expected '("ag" "--nocolor" "--nogroup" "--ignore=apple" "--ignore=orange"
-                         "somepattern")))
-        (should (equal got expected))))))
+  (let* ((helm-ag-ignore-patterns '("apple" "orange"))
+         (helm-ag--last-query "somepattern")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "--ignore=apple" "--ignore=orange"
+                     "somepattern")))
+    (should (equal got expected))))
 
-(ert-deftest construct-do-ag-command-with-extra-option ()
-  "helm-ag--construct-do-ag-command with extra options"
-  (let ((helm-ag-base-command "ag --nocolor --nogroup")
-        (helm-ag--extra-options "-G\\.md$"))
-    (let ((got (helm-ag--construct-do-ag-command "somepattern"))
-          (expected '("ag" "--nocolor" "--nogroup" "-G\\.md$" "somepattern")))
+(ert-deftest construct-command-with-extra-option-in-do-ag ()
+  "helm-ag--construct-command with extra options used in helm-do-ag"
+  (let* ((helm-ag-base-command "ag --nocolor --nogroup")
+         (helm-ag--extra-options "-G\\.md$")
+         (helm-ag--last-query "somepattern")
+         (got (helm-ag--construct-command))
+         (expected '("ag" "--nocolor" "--nogroup" "-G\\.md$" "somepattern")))
+    (should (equal got expected))))
+
+(ert-deftest construct-command-for-rg ()
+  "helm-ag--construct-command for rg base command"
+  (let* ((helm-ag-base-command "rg --no-heading")
+         (helm-ag--last-query "somepattern")
+         (got (helm-ag--construct-command))
+         (expected '("rg" "--no-heading" "somepattern")))
+    (should (equal got expected))))
+
+(ert-deftest construct-command-with-options-for-rg ()
+  "helm-ag--construct--command with options for rg base command"
+  (let ((helm-ag-base-command "rg --no-heading")
+        (helm-ag-command-option "--max-depth=5 -P")
+        (helm-ag--last-query "pattern"))
+    (let ((got (helm-ag--construct-command nil))
+          (expected '("rg" "--no-heading" "--max-depth=5" "-P"
+                      "pattern")))
+      (should (equal got expected)))))
+
+(ert-deftest construct-command-with-ignore-options-for-rg ()
+  "helm-ag--construct--command with options for rg base command"
+  (let ((helm-ag-base-command "rg --no-heading")
+        (helm-ag-command-option "--max-depth=5 -P")
+        (helm-ag--last-query "pattern"))
+    (let ((got (helm-ag--construct-command nil))
+          (expected '("rg" "--no-heading" "--max-depth=5" "-P"
+                      "pattern")))
+      (should (equal got expected)))))
+
+(ert-deftest construct-command-with-ignore-options-for-rg ()
+  "helm-ag--construct--command with ignore options for rg base command"
+  (let ((helm-ag-base-command "rg --no-heading")
+        (helm-ag-ignore-patterns '("*.md" "*.el"))
+        (helm-ag--last-query "foo"))
+    (let ((got (helm-ag--construct-command nil))
+          (expected '("rg" "--no-heading" "--glob=!*.md" "--glob=!*.el" "foo")))
       (should (equal got expected)))))
 
 (ert-deftest validate-regexp-with-valid-regexp ()
@@ -259,14 +304,14 @@
 (ert-deftest search-this-file-p ()
   (cl-letf (((symbol-function 'helm-get-current-source)
              (lambda () 'helm-source-ag))
-            ((symbol-function 'helm-attr)
+            ((symbol-function 'helm-get-attr)
              (lambda (attr &optional source compute)
                t)))
     (should (helm-ag--search-this-file-p)))
 
   (cl-letf (((symbol-function 'helm-get-current-source)
              (lambda () 'helm-source-do-ag))
-            ((symbol-function 'helm-attr)
+            ((symbol-function 'helm-get-attr)
              (lambda (attr &optional source compute)
                t)))
     (let ((helm-ag--default-target '("a.txt" "b.txt")))


### PR DESCRIPTION
# What are changes in this PR

Silver Searcher is a bit of out of active maintenance recently, it's regretful, and I'm recently trouble a lot by that "ag" doesn't recognize the negated rules in gitignore, so it caused some weird behaviors in a repo like [this one](https://github.com/npm/cli). It's a regret, I've been using helm-ag for a long while, thanks for the great efforts of the contributors, this tool benefits me a lot, especially for its robust command line option support and async helm source support (helm-do-ag). I noticed for a while that, helm-ag does attempt to support other searcher, including "pt", "ack" and "rg". However, I don't know why, the support just stops at replacing default base command with `helm-ag-base-command` custom variable, it doesn't really support the option syntax difference between searchers.

As "rg" now is the most popular searcher, it outweights others in performance, and it is under active development. To me, the good news is it supports gitignore well. After some painful tries on other emacs packages, like "rg", pure "helm grep" with rg backend etc..., it's hard to find a good balance between "helm", "rg" and "project search". So, I finally tried to harden helm-ag to support "rg" better. Hope this effort can make slight sense.

The changes I made in this PR includes:
- when you set `helm-ag-base-command` with a rg command, like "rg --no-heading", helm-ag now:
  - supports ".rgignore"
  - supports recognize `helm-ag-ignore-patterns`, and convert them into rg compatible format.
- some maintenance changes:
  - replaced deprecated `helm-attr` and `helm-attrset` with 'helm-get-attr` and `helm-set-attr`.
  - merged and normalized `helm-ag--construct-command` and `helm-ag--construct-do-ag-command`, they do same thing basically in different formats, very confusing. Now, consolidated under `helm-ag--construct-command`.
- add some new test cases.

# Tests
```
➜ make test
Testing...
eask test ert ./test/*.el
Running Eask in the development environment
Press Ctrl+C to cancel.

Executing script inside Emacs...

✓ Checking Emacs version 28.1... done!
✓ Checking system darwin... done!
✓ Try constructing the package-descriptor (helm-ag.el)... succeeded!
Unmatched website URL ’https://github.com/syohex/emacs-helm-ag’; add (website-url "https://github.com/syohex/emacs-helm-ag") to Eask-file
Keywords header is optional, but it’s often recommended
✓ Loading Eask file in /Users/zozo/CodeCenter/helm-ag/Eask... done!

Loading package information... done ✓
Loading /Users/zozo/CodeCenter/helm-ag/test/test-util.el (source)...
Running 23 tests (2022-10-06 22:03:02+0800, selector ‘t’)
   passed   1/23  construct-command (0.000362 sec)
   passed   2/23  construct-command-for-rg (0.000237 sec)
   passed   3/23  construct-command-in-do-ag (0.001074 sec)
   passed   4/23  construct-command-this-file (0.000169 sec)
   passed   5/23  construct-command-with-extra-option-in-do-ag (0.000194 sec)
   passed   6/23  construct-command-with-ignore-options-for-rg (0.000168 sec)
   passed   7/23  construct-command-with-ignore-patterns (0.000164 sec)
   passed   8/23  construct-command-with-options (0.000256 sec)
   passed   9/23  construct-command-with-options-for-rg (0.000179 sec)
   passed  10/23  construct-command-with-options-in-input (0.000531 sec)
   passed  11/23  convert-to-emacs-lisp-regexp (0.000267 sec)
   passed  12/23  emacs-lisp-regexp-to-pcre (0.000125 sec)
   passed  13/23  join-pattern (0.000221 sec)
   passed  14/23  judge-ignore-case (0.000072 sec)
   passed  15/23  parse-query (0.000242 sec)
   passed  16/23  search-this-file-p (0.000135 sec)
   passed  17/23  set-command-features (0.000143 sec)
   passed  18/23  split-string (0.000186 sec)
   passed  19/23  transform-for-files (0.000073 sec)
   passed  20/23  transform-for-this-file (0.000051 sec)
   passed  21/23  validate-regexp-with-invalid-regexp (0.000041 sec)
   passed  22/23  validate-regexp-with-valid-regexp (0.000040 sec)
   passed  23/23  visited-buffers (0.013920 sec)

Ran 23 tests, 23 results as expected, 0 unexpected (2022-10-06 22:03:02+0800, 0.021485 sec)
```
