### PR TITLE
doc: fix wrong rg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Ripgrep uses exit-status 2 to indicate a partial success:
 
 ```lisp
 (custom-set-variables
- '(helm-ag-base-command "rg --no-heading")
+ '(helm-ag-base-command "rg --no-heading --line-number --color never")
  `(helm-ag-success-exit-status '(0 2)))
 ```
 


### PR DESCRIPTION
This is a fix for https://github.com/emacsorphanage/helm-ag/issues/403

Without `--line-number` option, `helm-ag-edit` does not work because it's unable to parse the result of `rg`.